### PR TITLE
Use `name` field for entity names

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
     given-names: Jodi
     orcid: "https://orcid.org/0000-0002-5098-5667"
   -
-    family-names: "The RISRS Team"
+    name: "The RISRS Team"
 date-released: 2021-09-10
 keywords: 
   - Retraction
@@ -50,6 +50,6 @@ references:
           given-names: Yoss
         - family-names: Howell
           given-names: Katherine
-        - family-names: "The RISRS Team"
+        - name: "The RISRS Team"
     title: "Recommendations from the Reducing the Inadvertent Spread of Retracted Science: Shaping a Research and Implementation Agenda Project"
     doi: 10.31222/osf.io/ms579


### PR DESCRIPTION
This PR: 

- Replaces two instances of `family-names` (which is part of the person object) with the respective `name` field from `entity`

This is in reaction to [this tweet](https://twitter.com/jschneider/status/1436397757040939009).

The current version does render the *Cite this repository* widget you're after, it's just a bit off in terms of the semantics of the fields. `family-names` is meant to be used for a person, which "The RISRS Team" arguably isn't 🙂. In the Citation FIle Format, teams, organizations, etc. are represented as [entity](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsentity) objects, which have a simple `name` field.

I appreciate that this may not be ideally documented. Do you have an idea how we could make the documentation better in this respect (or any other)? Is there something particular that would've helped get this "right" in the first place?

Did you use an example as starting point (which one), or look at the schema guide?

Thanks!